### PR TITLE
update socketcan to version 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "LGPL-3.0"
 authors = ["Janosch Reppnow <janoschre@gmail.com>"]
 
 [dependencies]
-socketcan = "1.7.0"
+socketcan = "2.0"
 async-io = "1.7.0"
 libc = "0.2.137"
 futures = "0.3.25"

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use clap::Parser;
 use futures::prelude::*;
 use futures::select;
 use smol::net::SocketAddr;
+use socketcan::Socket;
 
 use crate::async_can::AsyncCanSocket;
 
@@ -59,7 +60,7 @@ fn main() -> anyhow::Result<()> {
     smol::block_on(async {
         let (udp_sender, udp_receiver) = udp::create_udp_sockets(&args.bind, &args.remote).await.context("Creating UDP sockets..")?;
 
-        let can_socket: AsyncCanSocket = socketcan::CANSocket::open(&args.can).context("Trying to open async can socket..").context("Creating CAN socket..")?.into();
+        let can_socket: AsyncCanSocket = socketcan::CanSocket::open(&args.can).context("Trying to open async can socket..").context("Creating CAN socket..")?.into();
 
         select! {
             sent = udp::send(&can_socket, &udp_sender, Duration::from_millis(args.force_after_ms as u64), &args.remote).fuse() => sent.context("Trying to send frames to the remote.."),

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -16,13 +16,14 @@
  *  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-use anyhow::Context;
-use async_io::Timer;
-use futures::future::Fuse;
-use futures::{select, FutureExt};
-use smol::net::UdpSocket;
 use std::net::SocketAddr;
 use std::time::Duration;
+
+use anyhow::Context;
+use async_io::Timer;
+use futures::{FutureExt, select};
+use futures::future::Fuse;
+use smol::net::UdpSocket;
 
 use crate::async_can::AsyncCanSocket;
 use crate::proto;


### PR DESCRIPTION
Updating to the newer version of the socketcan library, but keeping only classic CAN functionality (no FD yet) for now. 